### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/edit.py
+++ b/edit.py
@@ -70,7 +70,7 @@ window.tag_uploadPath = '/upload.py?user=%s&pid=%s';
 <nav><a href="list.py?user=%s">&lt; list</a></nav>
 %s
 <h1>%s</h1>
-<a href="https://dx.doi.org/%s">doi link</a> | <a href="%s">scholar link</a> | %s
+<a href="https://doi.org/%s">doi link</a> | <a href="%s">scholar link</a> | %s
 <br/>
 <br/>
 <form enctype="multipart/form-data" action="upload.py?user=%s&pid=%s" method="post" id="file_form">

--- a/list.py
+++ b/list.py
@@ -166,7 +166,7 @@ for r in render:
       pdf = '<a href="%s">download</a>' % r[10]
     print '''<tr>
     <td class="exp">%s</td>
-    <td class="nexp"%s><a href="https://dx.doi.org/%s">link</a></td>
+    <td class="nexp"%s><a href="https://doi.org/%s">link</a></td>
     <td class="nexp"%s><a href="https://scholar.google.com/scholar?hl=en&q=%s&btnG=">scholar</a></td>
     <td class="nexp"%s><a href="edit.py?user=%s&pid=%s">edit</a></td>
     <td class="nexp"%s>%s</td>


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Yes, a bit ironic that they would change the URL of their service, but it's now [encrypted](https://www.ssllabs.com/ssltest/analyze.html?d=doi.org). Because the old links with the `dx` subdomain continue to work, there is no urgent need to do anything.

However, I'd hereby like to suggest to follow the new recommendation and update any code that generates new DOI links.

Cheers!